### PR TITLE
Prune TODO list

### DIFF
--- a/TODO
+++ b/TODO
@@ -13,9 +13,6 @@ This is a trimmed down version of Dag Wieers original TODO list.
 + Create anaconda-style metadata for booting an updated installation
 + Update Apt release info transparantly when mrepo config changes (Tom G. Christensen)
 
-### Reporting utility
-+ Logwatch configuration for mrepo
-
 ### Configuration
 + Allow to specify rsync/lftp options on a per distribution basis (see ~/.lftp/rc)
 + Add more working distributions to /etc/mrepo.conf.d/

--- a/TODO
+++ b/TODO
@@ -11,7 +11,6 @@ This is a trimmed down version of Dag Wieers original TODO list.
 
 ### Repository metadata
 + Create anaconda-style metadata for booting an updated installation
-+ Complain when a required tool is not available
 + Update Apt release info transparantly when mrepo config changes (Tom G. Christensen)
 
 ### Reporting utility

--- a/TODO
+++ b/TODO
@@ -3,7 +3,6 @@ This is a trimmed down version of Dag Wieers original TODO list.
 
 ### Back-end support
 + Add libcurl support and (optionally?) make it the default 
-+ NFS support enable by default, using autofs (waiting for Serge Sterckx)
 + Add support for SRPM files (just put them into one directory /SRPMS)
 + Check files that do not match the regexp and compare filename to rpm headers
 + Use mirrorlist option from .repo files as a source (for http)

--- a/TODO
+++ b/TODO
@@ -26,7 +26,6 @@ This is a trimmed down version of Dag Wieers original TODO list.
 
 ### Documentation
 + Add a mrepo and mrepo.conf manpage
-+ Add documentation on how to configure clients
 + Add documentation about chaining mrepo servers
 + Comment the code more (pydoc strings)
 + ZeroConf support (or documentation)

--- a/TODO
+++ b/TODO
@@ -1,15 +1,5 @@
 ### Disclaimer
-This is my TODO list. If you're interested in one of these features, there
-are 3 options. Either wait for someone to implement it, sponsor someone
-to implement it or implement it yourself.
-
-If you want to implement something, please contact me first so that we can
-discuss acceptable implementations. In some cases I haven't thought about
-it too deeply, but for others I know exactly what I require.
-
-If you have other nice ideas that you think would be an improvement, please
-contact me as well. :) Send an email to: Dag Wieers <dag@wieers.com>
-
+This is a trimmed down version of Dag Wieers original TODO list.
 
 ### Back-end support
 + Add libcurl support and (optionally?) make it the default 

--- a/TODO
+++ b/TODO
@@ -39,6 +39,3 @@ This is a trimmed down version of Dag Wieers original TODO list.
 
 ### Bugs
 + Correct file permissions/ownerships of packages in /var/mrepo (add umask option)
-
-### mrepousb tool
-+ Create a bootable USB stick and allow for 3rd party boot-images

--- a/TODO
+++ b/TODO
@@ -40,11 +40,5 @@ This is a trimmed down version of Dag Wieers original TODO list.
 ### Bugs
 + Correct file permissions/ownerships of packages in /var/mrepo (add umask option)
 
-### mrepocfg tool / generate a configuration for clients (Chandan Dutta Chowdhury)
-+ The tool should accept a URL as an argument
-+ Should have a list (-l) option to list the different distributions
-+ Should have a target (-t) option to specify the configuration output format (apt/yum/smart)
-+ It scans the URL given and looks for know repository metadata
-
 ### mrepousb tool
 + Create a bootable USB stick and allow for 3rd party boot-images

--- a/TODO
+++ b/TODO
@@ -26,7 +26,6 @@ This is a trimmed down version of Dag Wieers original TODO list.
 
 ### Documentation
 + Add a mrepo and mrepo.conf manpage
-+ Add documentation about chaining mrepo servers
 + Comment the code more (pydoc strings)
 + ZeroConf support (or documentation)
 + Comply with PEP8: http://www.python.org/dev/peps/pep-0008/

--- a/TODO
+++ b/TODO
@@ -12,7 +12,6 @@ This is a trimmed down version of Dag Wieers original TODO list.
 ### Repository metadata
 + Create anaconda-style metadata for booting an updated installation
 + Complain when a required tool is not available
-+ Add URPMI and Red Carpet support (help needed)
 + Update Apt release info transparantly when mrepo config changes (Tom G. Christensen)
 
 ### Reporting utility


### PR DESCRIPTION
Remove everything that is no longer relevant to this trimmed down fork of the codebase.

Anything we care about should become issues on this repo in time.