### PR TITLE
Only mirror packages matching arch with reposync

### DIFF
--- a/mrepo.py
+++ b/mrepo.py
@@ -1009,6 +1009,8 @@ def mirrorreposync(url, path, reponame, dist):
     if CONFIG.reposyncminrate:
         reposync_conf_contents += "minrate=%s\n" % CONFIG.reposyncminrate
 
+    # Only mirror packages exactly matching arch
+    reposync_conf_contents += "includepkgs=*.%s\n" % dist.arch
 
     (file_object, reposync_conf_file) = tempfile.mkstemp(text=True)
     handle = os.fdopen(file_object, 'w')

--- a/mrepo.py
+++ b/mrepo.py
@@ -981,6 +981,8 @@ def mirrorreposync(url, path, reponame, dist):
     if CONFIG.reposyncminrate:
         reposync_conf_contents += "minrate=%s\n" % CONFIG.reposyncminrate
 
+    # Only mirror packages exactly matching arch
+    reposync_conf_contents += "includepkgs=*.%s\n" % dist.arch
 
     (file_object, reposync_conf_file) = tempfile.mkstemp(text=True)
     handle = os.fdopen(file_object, 'w')


### PR DESCRIPTION
There are a few monolithic repositories that we mirror that put all versions and architectures in the same tree, which is painful to mirror, this at least reduces that somewhat.

This doesn't work if the package names are malformed and don't have an architecture in their filename.