### PR TITLE
reposync: Don't specify metadata-path

### DIFF
--- a/mrepo.py
+++ b/mrepo.py
@@ -1015,10 +1015,9 @@ def mirrorreposync(url, path, reponame, dist):
     handle.writelines(reposync_conf_contents)
     handle.close()
 
-    ret = run("%s %s --metadata-path %s/reposync --config '%s' --repoid %s --download-path '%s'" % (
+    ret = run("%s %s --config '%s' --repoid %s --download-path '%s'" % (
         CONFIG.cmd['reposync'],
         opts,
-        CONFIG.cachedir,
         reposync_conf_file,
         reponame,
         path,


### PR DESCRIPTION
If not set, this defaults to the value of `download-path`, which allows the output directory to be used directly as a clean mirror. This is needed for repositories that contain special additional metadata and/or modularity streams.

The downloaded metadata is ignored when rebuilding repositories, so this is otherwise harmless and matches what we do with `rsync`.